### PR TITLE
TASK EPA-15899 Make `buffer` under HTTPServerRequest public

### DIFF
--- a/Sources/KituraNet/HTTP/HTTPServerRequest.swift
+++ b/Sources/KituraNet/HTTP/HTTPServerRequest.swift
@@ -224,10 +224,11 @@ public class HTTPServerRequest: ServerRequest {
         self.remoteAddress = HTTPServerRequest.host(socketAddress: channel.remoteAddress)
     }
 
-    var buffer: BufferList?
+    /// Current buffer 
+    public var buffer: BufferList?
 
     /// Default buffer size used for creating a BufferList
-    let bufferSize = 2048
+    public let bufferSize = 2048
 
     /**
      Read a chunk of the body of the request.


### PR DESCRIPTION
TASK EPA-15899 Done making buffer under HTTPServerRequest public in order to be able to process under extended logging